### PR TITLE
Added "convenience" keys

### DIFF
--- a/include/PS2Kbd.h
+++ b/include/PS2Kbd.h
@@ -91,4 +91,13 @@ public:
 #define KEY_PAGE_DOWN    0xE07A
 #define KEY_PAUSE        0xE11477E1F014E077
 
+#define KEY_COMMA     0x41
+#define KEY_DOT       0x49
+#define KEY_DIV       0x4A
+#define KEY_SEMI      0x4C
+#define KEY_MINUS     0x4E
+#define KEY_APOS      0x52
+#define KEY_EQUAL     0x55
+#define KEY_BACKSPACE 0x66
+
 #endif // ESPECTRUM_PS2KBD_H

--- a/src/ESPectrum.cpp
+++ b/src/ESPectrum.cpp
@@ -485,6 +485,104 @@ void ESPectrum::processKeyboard() {
     bitWrite(Ports::base[0x1f], 2, !PS2Keyboard::keymap[KEY_CURSOR_DOWN]);
     bitWrite(Ports::base[0x1f], 3, !PS2Keyboard::keymap[KEY_CURSOR_UP]);
     bitWrite(Ports::base[0x1f], 4, !PS2Keyboard::keymap[KEY_ALT_GR]);
+
+    // "Convenience" keys
+
+    // BACKSPACE (Shift + 0)
+    uint8_t specialKeyState = PS2Keyboard::keymap[KEY_BACKSPACE];
+    if (specialKeyState != PS2Keyboard::oldmap[KEY_BACKSPACE])
+    {
+        bitWrite(Ports::base[0], 0, specialKeyState);
+        bitWrite(Ports::base[4], 0, specialKeyState);
+    }
+
+    // LEFT ARROW (Shift + 5)
+    specialKeyState = PS2Keyboard::keymap[KEY_CURSOR_LEFT];
+    if (specialKeyState != PS2Keyboard::oldmap[KEY_CURSOR_LEFT])
+    {
+        bitWrite(Ports::base[0], 0, specialKeyState);
+        bitWrite(Ports::base[3], 4, specialKeyState);
+    }
+
+    // DOWN ARROW (Shift + 6)
+    specialKeyState = PS2Keyboard::keymap[KEY_CURSOR_DOWN];
+    if (specialKeyState != PS2Keyboard::oldmap[KEY_CURSOR_DOWN])
+    {
+        bitWrite(Ports::base[0], 0, specialKeyState);
+        bitWrite(Ports::base[4], 4, specialKeyState);
+    }
+
+    // UP ARROW (Shift + 7)
+    specialKeyState = PS2Keyboard::keymap[KEY_CURSOR_UP];
+    if (specialKeyState != PS2Keyboard::oldmap[KEY_CURSOR_UP])
+    {
+        bitWrite(Ports::base[0], 0, specialKeyState);
+        bitWrite(Ports::base[4], 3, specialKeyState);
+    }
+
+    // RIGHT ARROW (Shift + 8)
+    specialKeyState = PS2Keyboard::keymap[KEY_CURSOR_RIGHT];
+    if (specialKeyState != PS2Keyboard::oldmap[KEY_CURSOR_RIGHT])
+    {
+        bitWrite(Ports::base[0], 0, specialKeyState);
+        bitWrite(Ports::base[4], 2, specialKeyState);
+    }
+
+    // = (Ctrl + L)
+    specialKeyState = PS2Keyboard::keymap[KEY_EQUAL];
+    if (specialKeyState != PS2Keyboard::oldmap[KEY_EQUAL])
+    {
+        bitWrite(Ports::base[7], 1, specialKeyState);
+        bitWrite(Ports::base[6], 1, specialKeyState);
+    }
+
+    // - (Ctrl + J)
+    specialKeyState = PS2Keyboard::keymap[KEY_MINUS];
+    if (specialKeyState != PS2Keyboard::oldmap[KEY_MINUS])
+    {
+        bitWrite(Ports::base[7], 1, specialKeyState);
+        bitWrite(Ports::base[6], 3, specialKeyState);
+    }
+
+    // ; (Ctrl + O)
+    specialKeyState = PS2Keyboard::keymap[KEY_SEMI];
+    if (specialKeyState != PS2Keyboard::oldmap[KEY_SEMI])
+    {
+        bitWrite(Ports::base[7], 1, specialKeyState);
+        bitWrite(Ports::base[5], 1, specialKeyState);
+    }
+
+    // ' (Ctrl + 7)
+    specialKeyState = PS2Keyboard::keymap[KEY_APOS];
+    if (specialKeyState != PS2Keyboard::oldmap[KEY_APOS])
+    {
+        bitWrite(Ports::base[7], 1, specialKeyState);
+        bitWrite(Ports::base[4], 3, specialKeyState);
+    }
+
+    // , (Ctrl + N)
+    specialKeyState = PS2Keyboard::keymap[KEY_COMMA];
+    if (specialKeyState != PS2Keyboard::oldmap[KEY_COMMA])
+    {
+        bitWrite(Ports::base[7], 1, specialKeyState);
+        bitWrite(Ports::base[7], 3, specialKeyState);
+    }
+
+    // . (Ctrl + M)
+    specialKeyState = PS2Keyboard::keymap[KEY_DOT];
+    if (specialKeyState != PS2Keyboard::oldmap[KEY_DOT])
+    {
+        bitWrite(Ports::base[7], 1, specialKeyState);
+        bitWrite(Ports::base[7], 2, specialKeyState);
+    }
+
+    // / (Ctrl + V)
+    specialKeyState = PS2Keyboard::keymap[KEY_DIV];
+    if (specialKeyState != PS2Keyboard::oldmap[KEY_DIV])
+    {
+        bitWrite(Ports::base[7], 1, specialKeyState);
+        bitWrite(Ports::base[0], 4, specialKeyState);
+    }
 }
 
 /* +-------------+


### PR DESCRIPTION
Added "convenience" keys. These keys don't exist on the real Spectrum, however since they are present on the PS/2 keyboard, why not? Backspace arrows (left right up down) - = ; ' , . /