### PR TITLE
Typo in path of library

### DIFF
--- a/src/ESPectrum.cpp
+++ b/src/ESPectrum.cpp
@@ -30,7 +30,7 @@
 #include "PS2Kbd.h"
 #include "Z80_LKF/z80emu.h"
 #include "CPU.h"
-#include "z80_LKF/z80user.h"
+#include "Z80_LKF/z80user.h"
 #include <Arduino.h>
 
 #include "hardpins.h"


### PR DESCRIPTION
There's a typo in line 33 in the name of the folder  "z80_LKF/z80user.h" should be "Z80_LKF/z80user.h" (with capital Z in the first one) to prevent a compilation error in linux.